### PR TITLE
Update ade.parameters.json

### DIFF
--- a/infra/environments/frontend/ade.parameters.json
+++ b/infra/environments/frontend/ade.parameters.json
@@ -1,5 +1,5 @@
 {
-  "applicationName": "aibox",
+  "applicationName": "aiboxcicd",
   "logAnalyticsWorkspaceName":"la-logging-dev-eus",
   "logAnalyticsResourceGroupName": "rg-logging-dev-eus",
   "adeName": "cicd-fd",


### PR DESCRIPTION
This pull request updates the `applicationName` parameter in the `ade.parameters.json` file to reflect a new naming convention for the application.

* [`infra/environments/frontend/ade.parameters.json`](diffhunk://#diff-d3335a99e0c09843fd09b8e62d4d347f776574d25d0c96fd2fa7c8637cac653dL2-R2): Changed the `applicationName` from `"aibox"` to `"aiboxcicd"` to align with the application's CI/CD naming convention.