### PR TITLE
Refactor resource group name extraction to follow ADE naming convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,9 @@ jobs:
           --name "${{ env.ADE_ENVIRONMENT_NAME }}" \
           --output json)
         
-        # Extract resource group name
-        RESOURCE_GROUP=$(echo "$ENV_DETAILS" | jq -r '.resourceGroupId' | sed 's|.*/||')
+        # Construct resource group name using ADE naming convention: {project}-{adeName}
+        # Based on ade.parameters.json: devCenterProjectName + "-" + adeName
+        RESOURCE_GROUP="ai-foundry-${{ env.ADE_ENVIRONMENT_NAME }}"
         echo "RESOURCE_GROUP_NAME=$RESOURCE_GROUP" >> $GITHUB_ENV
         
         echo "🔍 Querying deployment outputs from resource group: $RESOURCE_GROUP"
@@ -400,8 +401,9 @@ jobs:
           --name "${{ env.ADE_ENVIRONMENT_NAME }}" \
           --output json)
         
-        # Extract resource group name
-        RESOURCE_GROUP=$(echo "$ENV_DETAILS" | jq -r '.resourceGroupId' | sed 's|.*/||')
+        # Construct resource group name using ADE naming convention: {project}-{adeName}
+        # Based on ade.parameters.json: devCenterProjectName + "-" + adeName
+        RESOURCE_GROUP="ai-foundry-${{ env.ADE_ENVIRONMENT_NAME }}"
         echo "RESOURCE_GROUP_NAME=$RESOURCE_GROUP" >> $GITHUB_ENV
         
         echo "🔍 Querying deployment outputs from resource group: $RESOURCE_GROUP"


### PR DESCRIPTION
This pull request updates the resource group naming convention in the CI workflow file to align with the ADE (Azure Deployment Environment) naming convention. The changes ensure consistency and clarity in resource group names.

Key changes:

### Workflow updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL140-R142): Modified the construction of the `RESOURCE_GROUP` variable to use the ADE naming convention `{project}-{adeName}`, replacing the previous method of extracting the resource group name from `ENV_DETAILS`. The new format explicitly includes the project name (`ai-foundry`) and ADE environment name. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL140-R142) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL403-R406)