### PR TITLE
Remove redundant return statement from agent deployment result output

### DIFF
--- a/infra/agent_deploy.ps1
+++ b/infra/agent_deploy.ps1
@@ -579,8 +579,6 @@ try {
             
             # Output results for consumption by Bicep deployment script
             Write-Host "AGENT_DEPLOYMENT_RESULT: $($result | ConvertTo-Json -Compress)" -ForegroundColor Green
-            
-            return $result
         }
         else {
             throw "Agent operation succeeded but no agent ID returned in response"


### PR DESCRIPTION
This pull request includes a minor change to the `infra/agent_deploy.ps1` script. The change removes an unnecessary `return $result` statement from the `try` block, simplifying the code.