### PR TITLE
Replace Write-Host with Write-Output for agent deployment result logging

### DIFF
--- a/infra/agent_deploy.ps1
+++ b/infra/agent_deploy.ps1
@@ -578,7 +578,7 @@ try {
             }
             
             # Output results for consumption by Bicep deployment script
-            Write-Host "AGENT_DEPLOYMENT_RESULT: $($result | ConvertTo-Json -Compress)" -ForegroundColor Green
+            Write-Output "AGENT_DEPLOYMENT_RESULT: $($result | ConvertTo-Json -Compress)"
         }
         else {
             throw "Agent operation succeeded but no agent ID returned in response"
@@ -612,7 +612,7 @@ catch {
         timestamp = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
     }
     
-    Write-Host "AGENT_DEPLOYMENT_RESULT: $($failureResult | ConvertTo-Json -Compress)" -ForegroundColor Red
+    Write-Output "AGENT_DEPLOYMENT_RESULT: $($failureResult | ConvertTo-Json -Compress)"
     
     # Exit with error code for Bicep deployment script
     exit 1


### PR DESCRIPTION
This pull request updates the logging mechanism in the `infra/agent_deploy.ps1` script to standardize the output method for deployment results. The changes replace `Write-Host` with `Write-Output` for better compatibility and consistency.

Logging updates:

* Replaced `Write-Host` with `Write-Output` for successful agent deployment results in the `try` block. This ensures the output is properly captured by external scripts or pipelines.
* Replaced `Write-Host` with `Write-Output` for failure results in the `catch` block. This aligns error logging with the same standardized output method.