### PR TITLE
refactor: Update AI Foundry instance references and RBAC assignments …

### DIFF
--- a/infra/environments/backend/main.bicep
+++ b/infra/environments/backend/main.bicep
@@ -324,7 +324,7 @@ resource functionAppStorageBlobRoleAssignment 'Microsoft.Authorization/roleAssig
 // Azure AI User role assignment for Function App to access AI Foundry
 // Required for reading and calling AI Foundry agents at the project level
 module aiFoundryUserRbac 'rbac.bicep' = {
-  name: 'backend-aifoundry-user-rbac-${uniqueString(resourceGroup().id)}'
+  name: 'backend-aifoundry-user-rbac-${uniqueString(resourceGroup().id, resourceNames.functionApp)}'
   scope: resourceGroup(aiFoundryResourceGroupName)
   params: {
     principalId: functionApp.outputs.systemAssignedMIPrincipalId!

--- a/infra/environments/backend/main.bicep
+++ b/infra/environments/backend/main.bicep
@@ -97,8 +97,8 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09
   scope: resourceGroup(logAnalyticsResourceGroupName)
 }
 
-// Reference to existing AI Foundry hub/project instance
-resource aiFoundryInstance 'Microsoft.MachineLearningServices/workspaces@2024-04-01' existing = {
+// Reference to existing AI Foundry Cognitive Services instance
+resource aiFoundryInstance 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {
   name: aiFoundryInstanceName
   scope: resourceGroup(aiFoundryResourceGroupName)
 }
@@ -321,41 +321,33 @@ resource functionAppStorageBlobRoleAssignment 'Microsoft.Authorization/roleAssig
   }
 }
 
-// Cognitive Services OpenAI User role for Function App managed identity to access AI Foundry
-// Required for creating threads, sending messages, and reading responses from AI Foundry agents
-// This role provides the necessary permissions for AI Foundry API access with least privilege
-// Using a separate module deployment to handle cross-resource group RBAC assignment
-// NOTE: The deploying identity must have User Access Administrator or Owner role on the AI Foundry resource group
-module functionAppAiFoundryRoleAssignment 'rbac.bicep' = {
-  name: 'functionApp-aiFoundry-rbac-${regionReference[location]}-${uniqueString(resourceGroup().id, resourceNames.functionApp)}'
+// Azure AI User role assignment for Function App to access AI Foundry
+// Required for reading and calling AI Foundry agents at the project level
+module aiFoundryUserRbac 'rbac.bicep' = {
+  name: 'backend-aifoundry-user-rbac-${uniqueString(resourceGroup().id)}'
   scope: resourceGroup(aiFoundryResourceGroupName)
   params: {
     principalId: functionApp.outputs.systemAssignedMIPrincipalId!
-    roleDefinitionId: subscriptionResourceId(
-      'Microsoft.Authorization/roleDefinitions',
-      'a97b65f3-24c7-4388-baec-2e87135dc908'
-    ) // Cognitive Services OpenAI User
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d')
     targetResourceId: aiFoundryInstance.id
     principalType: 'ServicePrincipal'
   }
 }
 
-// Azure AI User role for Function App managed identity to access AI Foundry Project
-// Required for reading and calling the AI Foundry agent, accessing project-level resources
-// This complements the Cognitive Services OpenAI User role for complete agent access
-module functionAppAiFoundryProjectRoleAssignment 'rbac.bicep' = {
-  name: 'functionApp-aiproject-rbac-${regionReference[location]}-${uniqueString(resourceGroup().id, resourceNames.functionApp)}'
+// Cognitive Services OpenAI User role assignment for Function App to access AI Foundry
+// Required for creating threads, sending messages, and reading responses
+module aiFoundryOpenAIRbac 'rbac.bicep' = {
+  name: 'backend-aifoundry-openai-rbac-${uniqueString(resourceGroup().id)}'
   scope: resourceGroup(aiFoundryResourceGroupName)
   params: {
     principalId: functionApp.outputs.systemAssignedMIPrincipalId!
-    roleDefinitionId: subscriptionResourceId(
-      'Microsoft.Authorization/roleDefinitions',
-      '53ca6127-db72-4b80-b1b0-d745d6d5456d'
-    ) // Azure AI User
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
     targetResourceId: aiFoundryInstance.id
     principalType: 'ServicePrincipal'
   }
 }
+
+// NOTE: AI Foundry RBAC assignments are now handled locally in the backend environment
 
 // =========== OUTPUTS ===========
 

--- a/infra/main-orchestrator.bicep
+++ b/infra/main-orchestrator.bicep
@@ -355,7 +355,7 @@ module backendInfrastructure 'environments/backend/main.bicep' = {
     logAnalyticsWorkspaceName: effectiveLogAnalyticsWorkspaceName
     logAnalyticsResourceGroupName: effectiveLogAnalyticsResourceGroupName
     aiFoundryInstanceName: effectiveCognitiveServicesAccount
-    aiFoundryResourceGroupName: aiFoundryResourceGroupName
+    aiFoundryResourceGroupName: effectiveAiFoundryResourceGroupName
     aiFoundryEndpoint: effectiveAiFoundryEndpoint
     aiFoundryAgentId: aiFoundryAgentId
     aiFoundryAgentName: aiFoundryAgentName
@@ -363,39 +363,6 @@ module backendInfrastructure 'environments/backend/main.bicep' = {
     tags: union(tags, {
       Component: 'Backend'
     })
-  }
-}
-
-// =========== RBAC ASSIGNMENT ===========
-
-// Deploy RBAC assignments for Function App to access AI Foundry (always runs regardless of new/existing)
-// Azure AI User role - Required for reading and calling AI Foundry agents at the project level
-module aiFoundryUserRbac 'modules/rbac-assignment.bicep' = {
-  name: 'aifoundry-user-rbac-assignment-${regionReference[location]}'
-  scope: resourceGroup(effectiveAiFoundryResourceGroupName)
-  params: {
-    principalId: backendInfrastructure.outputs.functionAppSystemAssignedIdentityPrincipalId
-    roleDefinitionId: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User role
-    principalType: 'ServicePrincipal'
-    targetResourceId: createAiFoundryResourceGroup
-      ? aiFoundryInfrastructure.?outputs.cognitiveServicesId ?? ''
-      : existingCognitiveServices.?id ?? ''
-    roleDescription: 'Grants Function App access to read and call AI Foundry agents'
-  }
-}
-
-// Cognitive Services OpenAI User role - Required for creating threads, sending messages, and reading responses
-module aiFoundryOpenAIRbac 'modules/rbac-assignment.bicep' = {
-  name: 'aifoundry-openai-rbac-assignment-${regionReference[location]}'
-  scope: resourceGroup(effectiveAiFoundryResourceGroupName)
-  params: {
-    principalId: backendInfrastructure.outputs.functionAppSystemAssignedIdentityPrincipalId
-    roleDefinitionId: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services OpenAI User role
-    principalType: 'ServicePrincipal'
-    targetResourceId: createAiFoundryResourceGroup
-      ? aiFoundryInfrastructure.?outputs.cognitiveServicesId ?? ''
-      : existingCognitiveServices.?id ?? ''
-    roleDescription: 'Grants Function App access to AI Foundry chat completion service'
   }
 }
 

--- a/infra/modules/rbac-assignment.bicep
+++ b/infra/modules/rbac-assignment.bicep
@@ -21,10 +21,14 @@ param targetResourceId string
 @description('Description of the role assignment purpose')
 param roleDescription string = ''
 
+@description('Unique suffix to append to GUID generation for role assignment naming (optional)')
+param uniqueSuffix string = ''
+
 // =========== VARIABLES ===========
 
 // Generate a deterministic GUID for the role assignment name to avoid conflicts
-var roleAssignmentName = guid(targetResourceId, principalId, roleDefinitionId)
+// Include uniqueSuffix to ensure uniqueness when multiple assignments might conflict
+var roleAssignmentName = guid(targetResourceId, principalId, roleDefinitionId, uniqueSuffix)
 
 // =========== RESOURCES ===========
 


### PR DESCRIPTION
This pull request refactors the infrastructure Bicep templates to update resource references, simplify RBAC assignments, and improve naming conventions. Key changes include transitioning to newer Cognitive Services APIs, consolidating RBAC assignments within the backend environment, and introducing a mechanism to avoid naming conflicts in role assignments.

### Resource Updates:
* Updated the `aiFoundryInstance` resource to use `Microsoft.CognitiveServices/accounts@2025-04-01-preview` instead of `Microsoft.MachineLearningServices/workspaces@2024-04-01`. This reflects a shift to Cognitive Services for AI Foundry integration.

### RBAC Assignment Simplification:
* Consolidated RBAC assignments for AI Foundry access within the backend environment, removing redundant modules from the orchestrator file. The assignments now locally handle both Azure AI User and Cognitive Services OpenAI User roles. [[1]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L324-R351) [[2]](diffhunk://#diff-3582defbfb42c6cf9c1f50b551c4f87ffe3b08453f1d2cda854751f2bbd8faa6L369-L401)

### Naming and Uniqueness Improvements:
* Added a `uniqueSuffix` parameter to the `rbac-assignment.bicep` module for deterministic GUID generation, ensuring uniqueness when multiple role assignments target the same resources.

### Parameter Adjustments:
* Updated `infra/main-orchestrator.bicep` to use `effectiveAiFoundryResourceGroupName` for consistency in parameter naming.…for improved clarity and functionality fixes #151