### PR TITLE
fix: allow deployment to proceed if ADE validation is skipped. closes…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,15 @@ jobs:
     name: Deploy Dev Infrastructure
     uses: ./.github/workflows/shared-infrastructure-deploy.yml
     needs: [bicep-validation, ade-validation-summary]
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && needs.ade-validation-summary.outputs.validation-status == 'success'
+    if: |
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') || 
+        github.event_name == 'workflow_dispatch' || 
+        github.event_name == 'schedule'
+      ) && (
+        needs.ade-validation-summary.outputs.validation-status == 'success' || 
+        needs.ade-validation-summary.result == 'skipped'
+      )
     with:
       environment: 'dev'
       bicep-template: 'infra/main-orchestrator.bicep'


### PR DESCRIPTION
This pull request updates the conditional logic for deploying development infrastructure in the CI workflow. The change refines the `if` condition to account for additional scenarios where the `ade-validation-summary` result may be skipped.

### Workflow logic refinement:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL604-R612): Updated the `if` condition in the `Deploy Dev Infrastructure` job to allow deployment when `needs.ade-validation-summary.result` is `skipped`, in addition to when `needs.ade-validation-summary.outputs.validation-status` is `success`. This ensures the workflow can proceed in cases where validation is intentionally bypassed.… #192 closes #191 closes #190