### PR TITLE
fix: remove unused ADE and DevCenter project parameters from environm…

### DIFF
--- a/infra/environments/backend/ade.parameters.json
+++ b/infra/environments/backend/ade.parameters.json
@@ -1,5 +1,5 @@
 {
-  "applicationName": "cbotcicd",
+  "applicationName": "aiboxcicd",
   "aiFoundryInstanceName": "cs-ai-foundry-dev-eus2",
   "aiFoundryResourceGroupName": "rg-ai-foundry-spa-aifoundry-dev-eus2",
   "aiFoundryEndpoint": "https://cs-ai-foundry-dev-eus2.services.ai.azure.com/api/projects/aiproj-ai-foundry-dev-eus2",
@@ -7,8 +7,6 @@
   "aiFoundryAgentName": "AI in A Box",
   "logAnalyticsWorkspaceName": "la-logging-dev-eus",
   "logAnalyticsResourceGroupName": "rg-logging-dev-eus",
-  "adeName": "cicd-backend",
-  "devCenterProjectName": "ai-foundry",
   "tags": {
     "Purpose": "CI-CD-Validation",
     "Component": "Backend",

--- a/infra/environments/backend/main.bicep
+++ b/infra/environments/backend/main.bicep
@@ -4,8 +4,6 @@
 targetScope = 'resourceGroup'
 
 // =========== PARAMETERS ===========
-@description('Name for the Azure Deployment Environment')
-param adeName string = ''
 
 @description('AI Foundry hub/project instance name')
 param aiFoundryInstanceName string
@@ -25,7 +23,6 @@ param aiFoundryAgentName string = 'AI in A Box'
 @description('Application name used for resource naming')
 param applicationName string
 
-param devCenterProjectName string = ''
 @description('Environment name (e.g., dev, staging, prod)')
 param environmentName string = 'dev'
 
@@ -45,9 +42,7 @@ param tags object = {
 }
 
 // =========== VARIABLES ===========
-var nameSuffix = empty(adeName)
-  ? toLower('${applicationName}-${typeInfrastructure}-${environmentName}-${regionReference[location]}')
-  : '${devCenterProjectName}-${adeName}'
+var nameSuffix = toLower('${applicationName}-${typeInfrastructure}-${environmentName}-${regionReference[location]}')
 var nameSuffixShort = replace(nameSuffix, '-', '')
 
 // Region reference mapping - ONLY regions where Cognitive Services AIServices are available
@@ -328,7 +323,10 @@ module aiFoundryUserRbac 'rbac.bicep' = {
   scope: resourceGroup(aiFoundryResourceGroupName)
   params: {
     principalId: functionApp.outputs.systemAssignedMIPrincipalId!
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d')
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '53ca6127-db72-4b80-b1b0-d745d6d5456d'
+    )
     targetResourceId: aiFoundryInstance.id
     principalType: 'ServicePrincipal'
   }
@@ -341,7 +339,10 @@ module aiFoundryOpenAIRbac 'rbac.bicep' = {
   scope: resourceGroup(aiFoundryResourceGroupName)
   params: {
     principalId: functionApp.outputs.systemAssignedMIPrincipalId!
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'a97b65f3-24c7-4388-baec-2e87135dc908'
+    )
     targetResourceId: aiFoundryInstance.id
     principalType: 'ServicePrincipal'
   }

--- a/infra/environments/frontend/ade.parameters.json
+++ b/infra/environments/frontend/ade.parameters.json
@@ -3,7 +3,6 @@
   "logAnalyticsWorkspaceName":"la-logging-dev-eus",
   "logAnalyticsResourceGroupName": "rg-logging-dev-eus",
   "adeName": "cicd-fd",
-  "devCenterProjectName": "ai-foundry",
   "environmentName": "dev",
   "location": "eastus2",
   "tags": {

--- a/infra/environments/frontend/environment.yaml
+++ b/infra/environments/frontend/environment.yaml
@@ -24,18 +24,6 @@ parameters:
     description: Resource Group containing the Log Analytics Workspace
     type: string
     required: true
-
-  - id: adeName
-    name: ADE Name
-    description: Name for the Azure Deployment Environment
-    type: string
-    required: false
-    
-  - id: devCenterProjectName
-    name: DevCenter Project Name
-    description: Name of the DevCenter project
-    type: string
-    required: false
     
   - id: environmentName
     name: Environment Name

--- a/infra/environments/frontend/example-parameters.bicepparam
+++ b/infra/environments/frontend/example-parameters.bicepparam
@@ -1,9 +1,5 @@
 using 'main.bicep'
 
-// ADE configuration (empty for CI validation)
-param adeName = ''
-param devCenterProjectName = ''
-
 // Application configuration
 param applicationName = 'ai-foundry-spa'
 param environmentName = 'validation'

--- a/infra/environments/frontend/main.bicep
+++ b/infra/environments/frontend/main.bicep
@@ -5,13 +5,8 @@ targetScope = 'resourceGroup'
 
 // =========== PARAMETERS ===========
 
-@description('Name for the Azure Deployment Environment')
-param adeName string = ''
-
 @description('Application name used for resource naming')
 param applicationName string = 'aibox'
-
-param devCenterProjectName string = ''
 
 @description('Environment name (e.g., dev, staging, prod)')
 param environmentName string = 'dev'
@@ -33,9 +28,7 @@ param tags object = {
 
 // =========== VARIABLES ===========
 
-var nameSuffix = empty(adeName)
-  ? toLower('${applicationName}-${typeInfrastructure}-${environmentName}-${regionReference[location]}')
-  : '${devCenterProjectName}-${adeName}'
+var nameSuffix = toLower('${applicationName}-${typeInfrastructure}-${environmentName}-${regionReference[location]}')
 
 // Region reference mapping - ONLY regions where Cognitive Services AIServices are available
 // Source: az cognitiveservices account list-skus --query "[?kind=='AIServices'].locations[]" -o tsv | sort -u


### PR DESCRIPTION
This pull request includes updates to the backend and frontend infrastructure configuration files to streamline resource naming conventions and remove unused parameters. The changes primarily focus on simplifying deployment configurations and improving maintainability.

### Backend Configuration Updates:
- **Removed unused parameters**: Eliminated `adeName` and `devCenterProjectName` parameters from `infra/environments/backend/main.bicep` and related files, simplifying resource naming logic. [[1]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L7-L8) [[2]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L28) [[3]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L48-R45)
- **Updated `applicationName`**: Changed the application name from `cbotcicd` to `aiboxcicd` in `ade.parameters.json`.
- **Improved formatting for role definitions**: Adjusted the formatting of `roleDefinitionId` in RBAC modules for better readability. [[1]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L331-R329) [[2]](diffhunk://#diff-98b05f82e127c5a130134ba44943b30acf87b1da2cf716584a7eef91ff3e3559L344-R345)

### Frontend Configuration Updates:
- **Removed unused parameters**: Eliminated `adeName` and `devCenterProjectName` parameters from `infra/environments/frontend/main.bicep`, `environment.yaml`, and related files. [[1]](diffhunk://#diff-5a73a50092011e1d842841e7e47730aa560d568d475d3528d9518a1fa1200269L8-L15) [[2]](diffhunk://#diff-7f896f12a3595079e8b490553b7fd2a2a4828fab5e143cb94c5e5ad34d7d8220L28-L39) [[3]](diffhunk://#diff-3aaff5af1548521a494d87ee0bb00da7cc0b739be92c3d312965ce29bb1f8849L3-L6)
- **Simplified resource naming**: Updated `nameSuffix` variable logic to exclude unused parameters, aligning with the backend changes.…ent.yaml closes #200