### PR TITLE
fix: add Microsoft Learn integration to MCP configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,6 +4,11 @@
             "url": "https://api.githubcopilot.com/mcp/",
             "name": "GitHub Copilot",
             "description": "GitHub Copilot MCP integration for enhanced AI-powered development assistance"
+        },
+        "microsoft.docs.mcp": {
+            "url": "https://learn.microsoft.com/api/mcp",
+            "name": "Microsoft Learn",
+            "description": "Microsoft documentation and API reference for Azure, Bicep, and .NET development"
         }
     }
 }


### PR DESCRIPTION
This pull request updates the `.vscode/mcp.json` file to include a new MCP integration for Microsoft Learn. The addition provides documentation and API references for Azure, Bicep, and .NET development.