### PR TITLE
Fix condition for ADE validation job to include scheduled events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,7 @@ jobs:
         github.event_name == 'workflow_dispatch' || 
         github.event_name == 'schedule'
       ) && (
+        github.event_name == 'schedule' || 
         needs.ade-validation-summary.outputs.validation-status == 'success' || 
         needs.ade-validation-summary.result == 'skipped'
       )


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change adds an additional condition to the workflow's job execution logic, ensuring that scheduled events are handled appropriately.

closes #235 
closes #234 
closes #233 
closes #232 
closes #231 
closes #230 
closes #229 
closes #228 
closes #227 
closes #226 
closes #225 
