### PR TITLE
Fix CI scheduled run failures by updating deploy-dev-infrastructure c…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,11 @@ jobs:
     name: Deploy Dev Infrastructure
     uses: ./.github/workflows/shared-infrastructure-deploy.yml
     needs: [bicep-validation, ade-validation-summary]
+    # For scheduled runs: skip ADE validation and proceed directly to deployment
+    # For push/manual: require successful ADE validation or skip condition
     if: |
+      always() && 
+      needs.bicep-validation.result == 'success' &&
       (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') || 
         github.event_name == 'workflow_dispatch' || 


### PR DESCRIPTION
…ondition

- Add always() to allow job to run even when ADE validation is skipped
- Explicitly check bicep-validation success before proceeding
- Scheduled runs now correctly execute all deployment jobs (minus ADE)
- Resolves #241