### PR TITLE
Add dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Frontend dependencies (npm)
+  - package-ecosystem: "npm"
+    directory: "/src/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      vite:
+        patterns:
+          - "vite*"
+          - "@vitejs/*"
+      testing:
+        patterns:
+          - "jest*"
+          - "@testing-library/*"
+    
+  # Backend dependencies (.NET/NuGet)
+  - package-ecosystem: "nuget"
+    directory: "/src/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration to automate dependency updates for the project. With this addition, Dependabot will regularly check for and propose updates to frontend (npm), backend (.NET/NuGet), and GitHub Actions dependencies, helping to keep the codebase secure and up to date.

Dependency management automation:

* Added a `.github/dependabot.yml` file to enable automated dependency updates for npm (frontend), NuGet (.NET backend), and GitHub Actions, each scheduled to run weekly with limits on open pull requests.
* Configured dependency groups for npm updates, allowing related packages like `vite` and `testing` libraries to be updated together for easier management.