### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/src/frontend/tests/message-formatting.test.js
+++ b/src/frontend/tests/message-formatting.test.js
@@ -78,9 +78,14 @@ describe('Message Formatting and Conversation Logic', () => {
       const dangerousContent = '<script>alert("xss")</script>Hello'
       
       // Simulate basic HTML sanitization
-      const sanitized = dangerousContent
-        .replace(/<script.*?>.*?<\/script>/gi, '')
-        .replace(/<[^>]*>/g, '')
+      // Apply repeated removal of script blocks
+      let sanitized = dangerousContent;
+      let previous;
+      do {
+        previous = sanitized;
+        sanitized = sanitized.replace(/<script.*?>.*?<\/script>/gi, '');
+      } while (sanitized !== previous);
+      sanitized = sanitized.replace(/<[^>]*>/g, '');
       
       expect(sanitized).toBe('Hello')
       expect(sanitized).not.toContain('<script>')


### PR DESCRIPTION
Potential fix for [https://github.com/JFolberth/ai-in-a-box/security/code-scanning/6](https://github.com/JFolberth/ai-in-a-box/security/code-scanning/6)

To properly fix the “Incomplete multi-character sanitization” in this unit test, we should ensure that the script-removing regex is applied repeatedly until no more substitutions occur, as described in reputable mitigation advice. This avoids the pitfall where partial/overlapping/malformed script tags could remain in the string after a single replacement. For this code block, wrap the sanitization process into a function or in-line repeated application of the regex, looping until the input no longer changes. This can be done using a `do-while` loop directly in the test. The rest of the logic (removing all other HTML tags) can remain unchanged. No external dependencies are needed for this fix.

In summary:
- In test `'should sanitize HTML content'`, replace the current `sanitized` assignment with a loop that removes `<script.*?>.*?<\/script>` repeatedly until input no longer changes.
- Then run `.replace(/<[^>]*>/g, '')` as before.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
