### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -192,12 +192,23 @@ class ModernChatApp {
   }
 
   formatMessage(content) {
-    // Basic markdown-like formatting
-    return content
+    // Escape HTML special chars before formatting
+    const escaped = this.escapeHtml(content);
+    // Basic markdown-like formatting (safe)
+    return escaped
       .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
       .replace(/\*(.*?)\*/g, '<em>$1</em>')
       .replace(/`(.*?)`/g, '<code>$1</code>')
-      .replace(/\n/g, '<br>')
+      .replace(/\n/g, '<br>');
+  }
+
+  escapeHtml(str) {
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
 
   showTypingIndicator() {


### PR DESCRIPTION
Potential fix for [https://github.com/JFolberth/ai-in-a-box/security/code-scanning/7](https://github.com/JFolberth/ai-in-a-box/security/code-scanning/7)

To address this issue, any user input must be properly escaped **before** being injected as HTML, except for the minimal, intended markdown-like syntax.  
The ideal solution is to:
- Escape special HTML characters in the user input so that only allowed formatting (strong, em, code, br, etc.) is interpreted as HTML.
- Apply the markdown formatting **after** escaping, ensuring any inserted formatting tags can't be broken by malicious input.
- Alternatively, use a well-established markdown or HTML sanitization library (such as DOMPurify) to allow only the intended HTML tags.

**Implementation plan:**
- Update the `formatMessage` function to first escape all HTML-related characters (`<`, `>`, `&`, `"`, `'`) in the message text. You can write a simple `escapeHtml` helper function for this purpose.
- After escaping, apply the existing markdown formatting replacements so that only legitimate markdown is turned into HTML tags.
- If desired, add a whitelist sanitizer (e.g., DOMPurify) after formatting. For now, escaping should suffice for minimal formatting.
- Make changes only in `src/frontend/main.js`, specifically to `formatMessage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
